### PR TITLE
Update Filter for team to appear in ranking from matches played to matches won

### DIFF
--- a/model/ranking.js
+++ b/model/ranking.js
@@ -119,7 +119,7 @@ function applyRanking( teams ){
     let regions = [0,1,2];
 
     teams.forEach( t => {
-        if (t.matchesPlayed >= 10) {
+        if (t.wonMatches.length >= 3) {
             globalRank += 1;
             t.globalRank = globalRank;
         }
@@ -128,7 +128,7 @@ function applyRanking( teams ){
     regions.forEach( r => {
         let regionalRank = 0;
         teams.forEach( t => {            
-            if ( t.matchesPlayed >= 10 && t.region[r] === 1 ) {
+            if ( t.wonMatches.length >= 3 && t.region[r] === 1 ) {
                 regionalRank += 1;
                 t.regionalRank[r] = regionalRank;
             }    


### PR DESCRIPTION
In the past (pre-2025), tournaments could invite teams they wanted, even if they where not yet ranked on the VRS. This allowed new teams with semi popular players (not good enough for Wildcard invites, but well known in the Tier 2/3 scene) to enter the ranking by playing 10 games or more. For those teams open qualifiers are now the only possiblity to enter the ranking. Winning one open qualifier will most likely not be enough to reach 10 games even with the following closed qualifier. Even winning two could not be enough. And the number of open qualifiers are limited. 

Thus in 2025, the filter for when a team needs to be in the ranking should be reduced from 10 to a lower number (e.g. 5). Additionally it would make sense to also base this filter on merit and not just on played games. My suggestion is thus, to change the filter to number of games won instead. My suggested value would be 3 games won.