### PR TITLE
Update region for Far East Russian teams to be on Asia VRS

### DIFF
--- a/model/util/region.js
+++ b/model/util/region.js
@@ -262,17 +262,40 @@ var regionMap = [
     { countrycode : 've', region : 'SA' },    
 ];
 
-function getCountryRegion( playerCountry ){
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+// Area/Postal Codes for Russia (EU VS Far East), first 2 digits
 
-    let record = regionMap.filter( el => el.countrycode.toLowerCase() === playerCountry.toLowerCase() )[0];
+var FarEastRUPostalCode = [
+    { FarEastRUPostalCode : 67, region : 'AS' },
+    { FarEastRUPostalCode : 68, region : 'AS' },
+    { FarEastRUPostalCode : 69, region : 'AS' },
+];
+
+function getCountryRegion(playerCountry) {
+    let record = regionMap.filter(el => el.countrycode.toLowerCase() === playerCountry.toLowerCase())[0];
     let region = record.region;
 
-    if ( region === 'EU' ){
+    if (region === 'NA' || region === 'SA') {
+        return 1;
+    }
+
+    if (region === 'AS') {
+        return 2;
+    }
+
+    if (region === 'EU') {
+        if (playerCountry.toLowerCase() === 'ru') {
+            for (let postalCodeRecord of FarEastRUPostalCode) {
+                let postalCode = postalCodeRecord.FarEastRUPostalCode;
+                if (postalCode < 70 && postalCode > 66) {
+                    return 2;
+                }
+            }
+            return 0;
+        }
         return 0;
     }
 
-    if ( region === 'NA' || region === 'SA' )
-        return 1;
-
-    return 2;
+    return 0;
 }


### PR DESCRIPTION
Far East Russian teams are denied the opportunity to play in the majority of Asian events, even if they have more VRS points than the actual invite teams, play in Asian tournaments and are literally from Asia. Far East Russian teams have better ping to Asia servers & usually play in Asian tournaments (Far East teams actively play in Asia due to the ping being unplayable to EU servers, and even a far east Russian team was invited to the closed qualifiers and qualified for the previous Perfect World Shanghai Major Asia RMR). Far East Russia is also geographically in Asia (it's a part of North Asia, see below). 

We suggest classifying the European and Far East (Asian) sides through using the postal codes of their area of citizenship, since Far East Russians would have a postal code ranging from 670000 to 699999

000000 to 669999: European Russian (Region: EU)
670000 to 699999: Far Eastern Russian (Region: AS)

To get this info, you can ask these teams to refill in the HLTV form via email to verify they are from Far East Russia, or give them your contact to verify & switch them to Far East Russians to get on the Asia VRS and play in Asian tournaments. (All far east teams are willing & able to prove this)



Far East Russia is part of Asia geographically: 
https://en.wikipedia.org/wiki/Russian_Far_East#:~:text=The%20Russian%20Far%20East%20 https://www.geeksforgeeks.org/russia-in-which-continent/

Areas that are part of the Far East: https://en.wikipedia.org/wiki/Far_Eastern_Federal_District

Area/Postal Codes of the Far East: https://en.wikipedia.org/wiki/Postal_codes_in_Russia#/media/File:Map_of_Russian_postal_codes.svg