### PR TITLE
Adjusting ranking algorithm - Glicko

### DIFF
--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -85,6 +85,7 @@ class Event {
         this.lan = eventJson.lan;
         this.lastMatchTime = -1;
         this.finished = eventJson.finished;
+        this.limitedScope = eventJson.limitedScope;
 
         eventJson.prizeDistribution.forEach( teamJson => {
             this.prizeDistributionByTeamId[teamJson.teamId] = new EventTeam( teamJson );

--- a/model/ranking.js
+++ b/model/ranking.js
@@ -20,6 +20,14 @@ const SEED_MODIFIER_FACTORS = {
 const MIN_SEEDED_RANK = 400;
 const MAX_SEEDED_RANK = 2000;
 
+function filterLimitedScopeEvents( matches, events ){
+    matches = matches.filter( match => {
+        return !events[ match.eventId ].limitedScope;
+    })
+
+    return matches;
+}
+
 function generateRanking( versionTimestamp = -1, filename )
 {
     // Parameters
@@ -31,6 +39,10 @@ function generateRanking( versionTimestamp = -1, filename )
 
     let teams = dataLoader.teams;
     let matches = dataLoader.matches;
+    let events = dataLoader.events;
+    let glickoMatches = dataLoader.matches;
+
+    glickoMatches = filterLimitedScopeEvents ( matches, events ); // only run H2H on events that have full scope
 
     const glicko = new Glicko();
     glicko.setFixedRD( 75 );        // glicko -> elo
@@ -39,7 +51,7 @@ function generateRanking( versionTimestamp = -1, filename )
     seedTeams( glicko, teams );
 
     // Adjust rankings based on games played
-    runMatches( glicko, matches );
+    runMatches( glicko, glickoMatches );
     teams.forEach( team => { team.rankValue = team.glickoTeam.rank(); } );
 
     // Remove rosters with no wins from the standings


### PR DESCRIPTION
Filtering the matches used in the glicko system so that it only includes matches played in tournaments with full scope.


For example, tournaments such as:
https://www.hltv.org/events/8395/intel-epic44
https://www.hltv.org/events/8390/cyberx-celebration-championship-2025
https://www.hltv.org/events/8079/fragadelphia-18

These tournaments receive a limited scope of coverage for what is their main stage (as defined in 1.7 of tournament-operation-requirements.md). This can lead to teams' success being punished, having progressed through the tournaments uncovered section of the main stage and then going out in their first covered match, where a ranked team will then lose points due to the H2H Adj. To counterract this, remove these matches from the H2H calculation.

This will also require such events to have an updated field for "limitedScope": true