### PR TITLE
Model improvement - event stakes

### DIFF
--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -85,6 +85,7 @@ class Event {
         this.lan = eventJson.lan;
         this.lastMatchTime = -1;
         this.finished = eventJson.finished;
+        this.tier = eventJson.tier; //A specified tier "1" , "2" or "Wildcard" must be added to the eventJson
 
         eventJson.prizeDistribution.forEach( teamJson => {
             this.prizeDistributionByTeamId[teamJson.teamId] = new EventTeam( teamJson );

--- a/model/ranking_context.js
+++ b/model/ranking_context.js
@@ -28,6 +28,19 @@ class RankingContext {
         return Math.pow( clamp, this.timeDecayFactor );
     }
 
+    getEventModifier( matchTimeStamp, eventTimeStamp ) {
+        // get event timestamp modifier, permitting a 1 month grace period on events that have finished within 30 days of the match.
+        let eventGracePeriod = matchTimeStamp - ( 1*30*24*3600 );
+        let matchWindowEnd = matchTimeStamp - ( 6*30*24*3600 );
+
+        if(eventTimeStamp > eventGracePeriod) {
+            return 1;
+        }
+
+        let clamp = remapValueClamped( eventTimeStamp, matchTimeStamp, matchWindowEnd, 0, 1 )
+        return Math.pow( clamp, this.timeDecayFactor );
+    }
+
     // Currently we use the same value for both prize pool outlier count, and distinct opponent outlier count.
     setOutlierCount( nth )
     {


### PR DESCRIPTION
## Data Source and limitations

- Initial data was generated via the Liquipedia API. This data has been heavily modified in an attempt to replicate the current matchdata.json, accounting for the correct scope and prizing that would be input from HLTV. This was a manual process and there are a few incorrect additions and ommissions, but should overall be quite accurate.

- There will be differences in decay due to a matchStartTime inaccuracy in the official dataset outlined here #19 . With additional differences due to how liquipedia occassionally does not split prizing the same was a HLTV as discussed in #15 , as well as HLTV not including a full event prizepool as discussed in the comments of #20. 

## Aim

Currently, the stakes of an event are solely dependent on the prizepool of that tournament. The current approach of splitting multi-stage events can lead to the earlier stage not accurately reflecting the stakes. This is due to prize pool slots awarding stage progression but then not accounting for the minimum prize pool guaranteed from this. This then classes progression slots as $0 when calculating event weight, leading to a significantly reduced stake.

This can lead to events with top ranked participants, playing meaningful and indicative matches, being allocated a stakes modifier which doesnt reflect the quality of the tournament.

An assumption is made that a teams previous accomplishments can be attributed to their previous winnings. In this PR, events can be weighted off the average winnings of the top teams competing in the event, if it is deemed as more reflective of the event quality. This will mean that multi-stage tournaments with top ranked participants will not be entirely beholden to a split event weighting if its participant quality is a more accurate representation of weight.

## Results

### Control - Using the current formula

Using the modified matchdata.json the current model produced a model fit as shown below:

![image](https://github.com/user-attachments/assets/6f381916-cbc5-4750-b49f-d1d76e209727)

It can be assumed that the recent increased scope, via lowering the match requirement, has led to a poorer fit than the initial model due to the increase in fringe data. However, there has been a noticeable decrease in relationship from the previously generated match fit.

### Alternative model

When using the same matchdata.json with the proposed alternative model for alternative weighting of events, the below model was generated:

![image](https://github.com/user-attachments/assets/bb2b0e8c-b714-434f-a04f-6f6ad6d793bb)

For the given matchdata.json, this model has led to an improvement in the expected relationship and an improvement in Spearman's rho. The data would also suggest an improved estimation rate for middle win rates, accounting for the most matches.

However, as this matchdata.json is not a perfect replica of what the current VRS is operating on, it is difficult to truly evaluate the model. Without this alternative approach being run on the Valve dataset it cannot be fully accurately interpreted or evaluated.

## Context within VRS

The assumption that a teams previous accomplishments can be attributed to their previous winnings should become more accurate as tournaments in 2025 onwards have to meet the operation requirements. As invites are now done on VRS rank, it is not possible to game the system by artifically creating an event to capitalise on this approach.

This model also provides little variation in [the top 20 generated rankings I have linked on the fork's separate branch.](https://github.com/MischiefCS/counter-strike_regional_standings/blob/event-weight-adj/experimentation/rescaled/live/2025/standings_global_2025_03_01.md) It primarily just produces a model which has better match prediction compared to a full shake up.

Given the aim of the Regional Standings to be "not easily gamed", wildcard events have been omitted from inputting into this stakes modification. This is to ensure that inputs are from tournaments that have been subject to the invite requirements, and met participants are based upon progression to that tier. Otherwise there is potential for artificially influencing the rankings.

## - 

This model should meet the aims of the regional standings, however true evaluation could only be completed on the true matchdata.json.
