### PR TITLE
A more recent alternative match sample for testing and evaluation of the model.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /data/*
 !/data/matchdata_sample*
 /tools
+/mischief

--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -58,14 +58,20 @@ function filterShowmatches( matches, events ){
 function filterUnrankedMatches( matches ) {
 
     return matches.filter( match => {
-        if ( match.matchStartTime < 1735689600 )
-            return true;
 
         if ( match.valveRanked === undefined )
             return false;
 
         return match.valveRanked;        
     });
+}
+
+function filterUnrankedEvents( matches, events ){
+    matches = matches.filter( match => {
+        return events[ match.eventId ].valveRanked;
+    })
+
+    return matches;
 }
 
 class EventTeam {
@@ -85,6 +91,7 @@ class Event {
         this.lan = eventJson.lan;
         this.lastMatchTime = -1;
         this.finished = eventJson.finished;
+        this.valveRanked = eventJson.valveRanked;
 
         eventJson.prizeDistribution.forEach( teamJson => {
             this.prizeDistributionByTeamId[teamJson.teamId] = new EventTeam( teamJson );
@@ -235,6 +242,9 @@ class DataLoader
         
         // Remove events that are in-progress
         matches = filterInProgressEvents( matches, events );
+
+        // Remove unranked events
+        matches = filterUnrankedEvents( matches, events );
 
         // Estimate the information content of each match (for example, recent matches may be considered
         // to have more accurate data about the current skill of players than old ones)

--- a/model/report.js
+++ b/model/report.js
@@ -123,7 +123,7 @@ function displayRankings( teams, regions = [0,1,2], strDate ) {
     output += '\n' + tableString + '\n';
 
     output += formatLine( '', true );
-    output += formatLine( '_Event data for Regional Standings provided by HLTV.org_' );
+    output += formatLine( '_Event data for Regional Standings produced via custom mischief_sample.json, in tandem with the liquipedia.net API_' );
 
     //console.log( output );
     return output;
@@ -297,7 +297,7 @@ function displayTeamRankingSummary( team, teams, strDate ){
     output += formatLine( `<span id="curveFunction"></span>_The Curve Function: 1 / ( 1 + abs( log10( x ) ) )_` );
     output += formatLine( '', true );
     output += formatLine( '---', true );
-    output += formatLine( '_Event data for Regional Standings provided by HLTV.org_' );
+    output += formatLine( '_Event data for Regional Standings produced by a custom mischief_sample.json, in tandem with the liquipedia.net API' );
 
     return output;
 }


### PR DESCRIPTION
Using the liquipedia API, manual cross reference and manual tweaks to create an alternative match sample. 

This enables tweaking of the VRS formula using data representative of the current climate. This PR also includes a tweak to the data loader to correctly handle limited scope events which have greater coverage on liquipedia. This isnt a perfect recreation but is pretty close to the current sample.