### PR TITLE
Improved consistency team initiation process.

### DIFF
--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -108,7 +108,7 @@ function initTeams( matches, events, rankingContext ) {
             // Use a consistent team assignment process, with team determined at branch diverge, compared to which team was initiated first.
             // Select the team with the most recent lastPlayed timestamp
             let team = matchingTeams.reduce((latest, team) => 
-                team.lastPlayed > latest.lastPlayed ? team : latest
+                team.lastPlayed < latest.lastPlayed ? team : latest
             );
 
             if (team.isPendingUpdate === true) {

--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -101,7 +101,6 @@ function initTeams( matches, events, rankingContext ) {
     let teams = [];
 
     function insertTeam( name, players, isForfeitMatch ) {
-
         let matchingTeams = teams.filter(team => team.sharesRoster(players));
 
         if (matchingTeams.length > 0) {
@@ -129,7 +128,7 @@ function initTeams( matches, events, rankingContext ) {
     }
 
         let rosterId = teams.length;
-        team = new Team( rosterId, name, players, isForfeitMatch );
+        let team = new Team( rosterId, name, players, isForfeitMatch );
         teams.push( team );
         return team;
     }

--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -102,16 +102,23 @@ function initTeams( matches, events, rankingContext ) {
 
     function insertTeam( name, players, isForfeitMatch ) {
 
-        let team = teams.find( team => team.sharesRoster(players) );
-        if( team !== undefined ){
-            if ( team.isPendingUpdate === true ){
+        let matchingTeams = teams.filter(team => team.sharesRoster(players));
+
+        if (matchingTeams.length > 0) {
+            // Use a consistent team assignment process, with team determined at branch diverge, compared to which team was initiated first.
+            // Select the team with the most recent lastPlayed timestamp
+            let team = matchingTeams.reduce((latest, team) => 
+                team.lastPlayed > latest.lastPlayed ? team : latest
+            );
+
+            if (team.isPendingUpdate === true) {
                 team.name = name;
                 team.players = players;
                 team.isPendingUpdate = isForfeitMatch;
             }
-            
-            return team;            
-        }
+
+        return team; // Return the matching team that follows branch diverge logic
+    }
 
         let rosterId = teams.length;
         team = new Team( rosterId, name, players, isForfeitMatch );

--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -106,10 +106,18 @@ function initTeams( matches, events, rankingContext ) {
 
         if (matchingTeams.length > 0) {
             // Use a consistent team assignment process, with team determined at branch diverge, compared to which team was initiated first.
-            // Select the team with the most recent lastPlayed timestamp
-            let team = matchingTeams.reduce((latest, team) => 
-                team.lastPlayed < latest.lastPlayed ? team : latest
-            );
+            // Select the team with the most recent match after the divergence
+            let team = matchingTeams.reduce((oldest, team) => {
+                let teamLastPlayed = team.teamMatches.length > 0
+                    ? Math.min(...team.teamMatches.map(m => m.match.timestamp))
+                    : Infinity; // Handle teams with no matches
+
+                let oldestLastPlayed = oldest.teamMatches.length > 0
+                    ? Math.min(...oldest.teamMatches.map(m => m.match.timestamp))
+                    : Infinity;
+
+                return teamLastPlayed < oldestLastPlayed ? team : oldest;
+            }, matchingTeams[0]);
 
             if (team.isPendingUpdate === true) {
                 team.name = name;


### PR DESCRIPTION
Currently when an existing team splits into two different branches, the split is handled dynamically depending on which branch has played the most recent match when future rankings are generated. This is because:

`let team = teams.find( team => team.sharesRoster(players) );`

will always find the first initiated team on model run, where teams are generated by reverse start time.

Currently this means that a split team's previous points and matches will always diverge to that more recent playing team. As shown below:

Image A:
![Screenshot 2025-04-02 114557](https://github.com/user-attachments/assets/1dee0f28-a1b3-4cfc-9589-b4c12d7ac8ea)

However, this is an incosistent approach, potentially leading to accidental re-assignemnt or possible gaming. Potentially it would be possible for an organisation with two teams to be able to rotate their teams in the rankings. This would be beneficial if their primary team has no requirement to be in the coming months invite rankings, having already accepted invites and already qualified to events that month. This is possible by being able to rotate which team branch has priority over the preceding data, by coordinating which branch has the most recent match, transferring the priority compared to Image A as shown below:


![Screenshot 2025-04-02 114621](https://github.com/user-attachments/assets/64f7b2fb-3217-4d7b-87fd-c564af9db848)


This PR introduces a more consistent approach for handling branch divergence. This is achieved by always assigning the branch divergence to follow the team which played the next applicable match, compared to being dynamically dependent on future generation, as shown below:


![Screenshot 2025-04-02 114831](https://github.com/user-attachments/assets/f3250363-69eb-4431-86b3-a5bcb8b412b9)

This approach should be a more consistent method, as well as closing any potential loopholes.



