### PR TITLE
Improved consistency team initiation process.

### DIFF
--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -103,22 +103,22 @@ function initTeams( matches, events, rankingContext ) {
     function insertTeam( name, players, isForfeitMatch ) {
         let matchingTeams = teams.filter(team => team.sharesRoster(players));
 
-        if (matchingTeams.length > 0) {
-            // Use a consistent team assignment process, with team determined at branch diverge, compared to which team was initiated first.
+        if ( matchingTeams.length > 0 ) {
+            // Utilise a consistent team assignment process, with team path determined at branch diverge, compared to which team was initiated first
             // Select the team with the most recent match after the divergence
-            let team = matchingTeams.reduce((oldest, team) => {
+            let team = matchingTeams.reduce(( oldest, team ) => {
                 let teamLastPlayed = team.teamMatches.length > 0
-                    ? Math.min(...team.teamMatches.map(m => m.match.timestamp))
+                    ? Math.min(...team.teamMatches.map(m => m.match.matchStartTime))
                     : Infinity; // Handle teams with no matches
 
                 let oldestLastPlayed = oldest.teamMatches.length > 0
-                    ? Math.min(...oldest.teamMatches.map(m => m.match.timestamp))
+                    ? Math.min(...oldest.teamMatches.map(m => m.match.matchStartTime))
                     : Infinity;
 
                 return teamLastPlayed < oldestLastPlayed ? team : oldest;
             }, matchingTeams[0]);
 
-            if (team.isPendingUpdate === true) {
+            if ( team.isPendingUpdate === true ) {
                 team.name = name;
                 team.players = players;
                 team.isPendingUpdate = isForfeitMatch;


### PR DESCRIPTION
Currently when an existing team splits into two different branches, the split is handled dynamically depending on which branch has played the most recent match when future rankings are generated. This is because:

`let team = teams.find( team => team.sharesRoster(players) );`

will always find the first initiated team on model run, where teams are generated by reverse start time.

Currently this means that a split team's previous points and matches will always diverge to that more recent playing team. As shown below:

Image A:
![Screenshot 2025-04-02 114557](https://github.com/user-attachments/assets/1dee0f28-a1b3-4cfc-9589-b4c12d7ac8ea)

However, this is an inconsistent approach, potentially leading to accidental re-assignment or possible gaming. Potentially it would be possible for an organisation with two teams to be able to rotate their teams in the rankings. This would be beneficial if their primary team has no requirement to be in the coming months' invite rankings, having already accepted invites and already qualified to events that month. This is possible by being able to rotate which team branch has priority over the preceding data, by coordinating which branch has the most recent match, transferring the priority compared to Image A as shown below:


![Screenshot 2025-04-02 114621](https://github.com/user-attachments/assets/64f7b2fb-3217-4d7b-87fd-c564af9db848)


This PR introduces a more consistent approach for handling branch divergence. This is achieved by always assigning the branch divergence to follow the team which played the next applicable match, compared to being dynamically dependent on future generation, as shown below:


![Screenshot 2025-04-02 114831](https://github.com/user-attachments/assets/f3250363-69eb-4431-86b3-a5bcb8b412b9)

This approach should be a more consistent method, as well as closing any potential loopholes.