### PR TITLE
Consistently handle diverging branches, aligned with the correct team shareRoster methodology.

### DIFF
--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -101,20 +101,34 @@ function initTeams( matches, events, rankingContext ) {
     let teams = [];
 
     function insertTeam( name, players, isForfeitMatch ) {
+        let matchingTeams = teams.filter(team => team.sharesRoster(players));
 
-        let team = teams.find( team => team.sharesRoster(players) );
-        if( team !== undefined ){
-            if ( team.isPendingUpdate === true ){
+        if ( matchingTeams.length > 0 ) {
+            // Utilise a consistent team assignment process, with team path determined at branch diverge, compared to which team was initiated first
+            // Select the team with the most recent match after the divergence
+            let team = matchingTeams.reduce(( oldest, team ) => {
+                let teamLastPlayed = team.teamMatches.length > 0
+                    ? Math.min(...team.teamMatches.map(m => m.match.matchStartTime))
+                    : Infinity; // Handle teams with no matches
+
+                let oldestLastPlayed = oldest.teamMatches.length > 0
+                    ? Math.min(...oldest.teamMatches.map(m => m.match.matchStartTime))
+                    : Infinity;
+
+                return teamLastPlayed < oldestLastPlayed ? team : oldest;
+            }, matchingTeams[0]);
+
+            if ( team.isPendingUpdate === true ) {
                 team.name = name;
                 team.players = players;
                 team.isPendingUpdate = isForfeitMatch;
             }
-            
-            return team;            
-        }
+
+        return team; // Return the matching team that follows branch diverge logic
+    }
 
         let rosterId = teams.length;
-        team = new Team( rosterId, name, players, isForfeitMatch );
+        let team = new Team( rosterId, name, players, isForfeitMatch );
         teams.push( team );
         return team;
     }


### PR DESCRIPTION
Apologies for the spam. Initially I had made a major misunderstanding, forgotting how the shareRoster check works. However, there is still an issue of diverging branches being handled inconsistently. I had incorrectly assumed that this branch divergence could lead to points manipulation for a team. This is not the case, however this inconsistent branch divergence can lead to the stakes of a match seeing significant change retroactively, which can be quite confusing. As well as impacting the opponent in these changed matches.

# Critical Path

Currently, below is how most cases are handled, with matches 1 through 11 sharing 3 players from when the team is initialised in matchId 11. The critical path of this roster is shown below:

![image](https://github.com/user-attachments/assets/bab3b5d1-3bf6-4d05-b8a1-373eba05ea5c)

However, the overlap for this team is very narrow. Certain conditions will cause the critical path to split, into the continuing critical path and a newly initiated team. As a new team has been initiated at the base points level, it will casue a retroactive impact on the point calculations for this match.

## Condition A

One of these conditions is when the left hand branch, makes a change which will not overlap with the original roster.

![image](https://github.com/user-attachments/assets/ed8046ec-a0ed-41cd-804a-1e40643860ff)

This is correctly handled, as the overlap is no longer consistent. This will lead to changed stakes for all matches, particularly 6-11 as it is treated as a brand new team. This is an accurate case though as the core has changed, indicating where the current branch logic works succesfully.


## Condition B
However, there is a variety of cases where a branch divergence incosistency can occur. For example, if  a right hand side branch based mix attend a local LAN, they can inadvertantly diverge the branches as shown below:

![image](https://github.com/user-attachments/assets/ec791613-72d5-4298-998f-8e9d0b57e30b)


This is because Match 12 is the first match in the reverse time order, initiating this team with an earlier index. Logically the rosterId branch should have followed from matchId 5 -> matchId 6. Unfortunately the current approach creates an accidental divergence due to each match accumulation prioritising the lower index team when two teams return a true shareRoster check. This will create an alternative branch compared to the earlier divergence.


## Condition C
A very similar condition to this is as shown below, where the right hand side would have inherited the points from previous matches, offering their opponents for matches 3-5 a match of set stakes at the time of the match:

![image](https://github.com/user-attachments/assets/a9d8ac31-7d59-495a-8e82-7607ce57300f)



But then due to a later change, these matches will be treated as a newly initialised team, significantly lowering the stakes for those played matches:

![image](https://github.com/user-attachments/assets/b415be66-f28e-424b-84f7-e373ca574fec)

## Condition D

Similar to condition B where the lower index initiated team is prioritised, you can then inadvertantly get oscillations in the rankings. If there are two branches which do not share a common overlap, but they both share a common start point, you can have a situation where the lower index team at rankings generation will be prioritised every time the rankings are run.

i.e Initially 

![image](https://github.com/user-attachments/assets/6eb13e02-5a53-4163-8d81-e1bf4e67887f)

But then swaps to:

![image](https://github.com/user-attachments/assets/78765a88-e5e1-4d1f-a2cf-29ccda85f1e4)


# Occurrences

These cases are very specific, and will occur rarely. However, they can occur as shown by ATOX. ATOX has had a branch divergence after 2024-10-04, where 9 matches were played on the right hand side branch:

### Right hand side branch after 2024-10-04
| Match Played | Match ID | Date       | Opponent                | W/L | Age Weight | Event Weight | Bounty Collected | Opponent Network | LAN Wins  | H2H Adj. | Roster                               |
| -: | -: | :- | :- | :- | :- | :- | :- | :- | :- | -: | :- |
|           20 |     1699 | 2024-11-02 | Lynn Vision Gaming      | L   | 0.410      | -            | -                | -                | -         |    -5.38 | flyNN, kabal, MiQ, nuka, yAmi        |
|           19 |     1718 | 2024-11-02 | TYLOO                   | L   | 0.405      | -            | -                | -                | -         |    -5.35 | flyNN, kabal, MiQ, nuka, yAmi        |
|           18 |     1896 | 2024-10-17 | Chinggis Warriors       | L   | 0.303      | -            | -                | -                | -         |    -4.06 | cool4st, kabal, MiQ, sk0R, yAmi      |
|           17 |     1917 | 2024-10-17 | Clutch Gaming           | W   | 0.297      | 0.333        | 0.000 (0.000)    | 0.056 (0.006)    | 1 (0.297) |     1.64 | cool4st, kabal, MiQ, sk0R, yAmi      |
|           16 |     1938 | 2024-10-16 | Lynn Vision Gaming      | W   | 0.292      | 0.417        | 0.011 (0.001)    | 0.301 (0.037)    | 1 (0.292) |     5.21 | flyNN, kabal, MiQ, nuka, yAmi        |
|           15 |     1945 | 2024-10-16 | Chinggis Warriors       | L   | 0.291      | -            | -                | -                | -         |    -3.95 | cool4st, kabal, MiQ, sk0R, yAmi      |
|           14 |     1961 | 2024-10-15 | Chinggis Warriors       | W   | 0.285      | 0.417        | 0.016 (0.002)    | 0.555 (0.066)    | 1 (0.285) |     5.21 | flyNN, kabal, MiQ, nuka, yAmi        |
|           13 |     1966 | 2024-10-14 | The QUBE Esports        | W   | 0.283      | 0.333        | 0.000 (0.000)    | 0.000 (0.000)    | 1 (0.283) |     0.86 | cool4st, kabal, MiQ, sk0R, yAmi      |
|           12 |     2217 | 2024-10-04 | Clutch Gaming           | W   | 0.211      | 0.143        | 0.000 (0.000)    | 0.056 (0.002)    | 1 (0.211) |     1.21 | cool4st, dobu, kabal, MiQ, yAmi      |

Instead of this divergence being dead-ended, condition C occurred where the branch was then re assigned as shown below:



### Left hand side branch after 2024-10-04, re-claiming the divergence point
| Match Played | Match ID | Date       | Opponent                  | W/L | Age Weight | Event Weight | Bounty Collected | Opponent Network | LAN Wins  | H2H Adj. | Roster                               |
| -: | -: | :- | :- | :- | :- | :- | :- | :- | :- | -: | :- |
|           31 |       16 | 2025-02-27 | HOTU                      | W   | 1.000      | -            | -                | -                | 0 (0.000) |     3.28 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           30 |       21 | 2025-02-26 | Eruption                  | W   | 1.000      | -            | -                | -                | 0 (0.000) |     8.42 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           29 |       35 | 2025-02-25 | The Huns Esports          | W   | 1.000      | 0.143        | 0.025 (0.004)    | 0.516 (0.074)    | 0 (0.000) |    10.05 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           28 |       53 | 2025-02-24 | Gods Reign                | W   | 1.000      | -            | -                | -                | -         |     8.41 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           27 |       75 | 2025-02-23 | HOTU                      | L   | 1.000      | -            | -                | -                | -         |   -28.21 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           26 |      297 | 2025-02-13 | The Huns Esports          | W   | 1.000      | 0.143        | 0.025 (0.004)    | 0.516 (0.074)    | -         |    10.32 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           25 |      300 | 2025-02-12 | Rare Atom                 | W   | 1.000      | 0.143        | 0.028 (0.004)    | -                | -         |     8.76 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           24 |      313 | 2025-02-12 | Lynn Vision Gaming        | L   | 1.000      | -            | -                | -                | -         |   -21.96 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           23 |      336 | 2025-02-11 | The Huns Esports          | W   | 1.000      | 0.143        | 0.025 (0.004)    | 0.516 (0.074)    | -         |    10.27 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           22 |      344 | 2025-02-11 | TYLOO                     | W   | 1.000      | -            | -                | -                | -         |     8.50 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           21 |      347 | 2025-02-10 | Rooster                   | W   | 1.000      | -            | -                | -                | -         |     3.28 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           20 |      739 | 2024-12-29 | Eruption                  | W   | 0.784      | 0.384        | 0.014 (0.004)    | 0.379 (0.114)    | 1 (0.784) |     7.72 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           19 |      740 | 2024-12-28 | Rare Atom                 | W   | 0.783      | 0.384        | 0.028 (0.008)    | 0.405 (0.122)    | 1 (0.783) |     6.58 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           18 |      746 | 2024-12-28 | The Huns Esports          | W   | 0.777      | 0.384        | 0.025 (0.007)    | 0.516 (0.154)    | 1 (0.777) |     8.78 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           17 |      747 | 2024-12-27 | Chinggis Warriors         | W   | 0.777      | 0.384        | 0.016 (0.005)    | 0.555 (0.166)    | 1 (0.777) |     5.89 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           16 |      753 | 2024-12-26 | Eruption                  | L   | 0.770      | -            | -                | -                | -         |   -16.81 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           15 |     1016 | 2024-12-06 | Chinggis Warriors         | W   | 0.632      | 0.333        | 0.016 (0.003)    | 0.555 (0.117)    | -         |     4.85 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           14 |     1022 | 2024-12-06 | DogEvil                   | W   | 0.631      | 0.333        | -                | 0.494 (0.104)    | -         |     1.34 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           13 |     1075 | 2024-12-04 | Just Swing (Chinese team) | W   | 0.618      | -            | -                | -                | -         |     2.68 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           12 |     1076 | 2024-12-04 | Nomads (Mongolian team)   | W   | 0.618      | -            | -                | -                | -         |     1.03 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           11 |     1081 | 2024-12-03 | IHC Esports               | L   | 0.617      | -            | -                | -                | -         |   -16.88 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|           10 |     1288 | 2024-11-23 | Just Swing (Chinese team) | W   | 0.544      | -            | -                | -                | -         |     2.29 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|            9 |     1296 | 2024-11-22 | CatEvil                   | W   | 0.543      | -            | -                | -                | -         |     1.02 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|            8 |     1365 | 2024-11-19 | IHC Esports               | W   | 0.524      | -            | -                | -                | -         |     2.07 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|            7 |     1366 | 2024-11-19 | Chinggis Warriors         | W   | 0.523      | 0.333        | -                | 0.555 (0.097)    | -         |     4.45 | AccuracyTG, dobu, kabal, MiQ, Zesta  |
|            6 |     2217 | 2024-10-04 | Clutch Gaming             | W   | 0.211      | -            | -                | -                | 1 (0.211) |     0.40 | cool4st, dobu, kabal, MiQ, yAmi      |



# PR Changes & Conclusion

This Pull Request aims to remove these potential conditions, by having a consistent branch divergence logic occur which applies at the point of divergence, instead of being determined by team intialisation order. This is done by when a match is accumulated with multiple eligible rosterIds (a divergence point), the rosterId with the most recent match relative to the divergence is assigned. This will create a consistent logic, that wont rely on which core has the lower index on each rankings generation.

This consistent logic would hopefully make the process simpler, as well as helping eliminate cases where match stakes change retroactively due to a branch diverging.

