### PR TITLE
Modifying VRS Model

### DIFF
--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -85,6 +85,11 @@ class Event {
         this.lan = eventJson.lan;
         this.lastMatchTime = -1;
         this.finished = eventJson.finished;
+        this.tier = eventJson.tier; // Assigned to tournament tier as outlined in the Tournament Operation Requirements.
+        this.openProportion = eventJson.openProportion ?? 1; 
+        // openProportion is a value submitted by a Tournament Operator for a specific event between 0 and 1, representing the percentage of paths that are open to the public.
+        // If an event contains a preceding tournament. The proportion of invites from that tournament is multiplied against the openProportion value of that event.
+        // In the case of multiple preceding tournaments and/or open qualifiers. These values can be summed to a total for the main event.
 
         eventJson.prizeDistribution.forEach( teamJson => {
             this.prizeDistributionByTeamId[teamJson.teamId] = new EventTeam( teamJson );

--- a/model/team.js
+++ b/model/team.js
@@ -116,7 +116,28 @@ class Team {
         function curveFunction( x ) { return Math.pow( 1 / ( 1 + Math.abs(Math.log10(x)) ), 1 ); }
         function powerFunction( x ) { return Math.pow( x, 1 ) };
         function getPrizePool( x ) { return Math.max(1, x.team.eventMap.get( x.match.eventId ).event.prizePool ) };
+        function getTier( x ) { return Math.max(1, x.team.eventMap.get( x.match.eventId ).event.tier ) };
+        function getOpenProportion ( x ) { return x.team.eventMap.get( x.match.eventId ).event.openProportion };
         function getLAN( x ) { return x.team.eventMap.get( x.match.eventId ).event.lan ? 1 : 0 };
+        function openCurveFunction(x, lan, tier) {
+            const proportion = Math.min( x, 1 );
+            const log10x = Math.log10(proportion);
+
+            // Different curve functions depending on whether the event is on LAN
+            const coeff = lan ? 0.5 : 0.25
+            const y = 1 - (coeff * (log10x ** 2));
+
+            // Clamping to a minimum 0.5 multiplier
+            let result = Math.max(y, 0.5);
+
+            // Only apply open proportion curve to Tier 2 tournaments
+            if (tier !== 2) {
+                result = 1;
+            }
+
+            return result;
+        }
+
 
         let bucketSize = 10; // used for all factors that track your top N results
 
@@ -152,7 +173,10 @@ class Team {
                 let timestampModifier = context.getTimestampModifier( matchTime );
                 let lan = getLAN( wonMatch );
                 let matchContext = timestampModifier;
-                let scaledLan = lan * matchContext;
+                let openProportion = getOpenProportion( wonMatch );
+                let tier = getTier( wonMatch );
+                let openContext = openCurveFunction ( openProportion, lan, tier );
+                let scaledLan = lan * matchContext * openContext;
                 lanWins.push( { id: id, context: matchContext, base: lan, val: scaledLan } );  
             });
 
@@ -206,9 +230,13 @@ class Team {
             team.wonMatches.forEach( teamMatch => {
                 let id = teamMatch.match.umid;
                 let timestampModifier = context.getTimestampModifier( teamMatch.match.matchStartTime );
+                let lan = getLAN( teamMatch );
                 let prizepool = getPrizePool( teamMatch );
+                let openProportion = getOpenProportion( teamMatch );
+                let tier = getTier( teamMatch );
+                let openContext = openCurveFunction ( openProportion , lan, tier );
                 let stakesModifier = curveFunction( Math.min( prizepool / 1000000, 1 ) ); //prizepool of the event is curved the same as a bounty, and is limited to $1,000,000.
-                let matchContext = timestampModifier * stakesModifier;
+                let matchContext = timestampModifier * openContext * stakesModifier;
 
                 let scaledBounty = teamMatch.opponent.bountyOffered * matchContext;
                 let scaledNetwork = teamMatch.opponent.ownNetwork * matchContext;


### PR DESCRIPTION
This PR is made related to the changes to VRS outlined in https://github.com/ValveSoftware/counter-strike_rules_and_regs/commit/2c85d431cb4788ca7cc57854759bf4fe01c8cae3. With the changes outlining the aim for community events to be the qualification path to the Majors, I believe its important to try and encourage more Open Qualifiers in the Tier 2 circuit.

Within the first 6 months of the VRS era, there has been a limited number of Tier 2 events with Open Qualifiers, making it hard for teams to progress upwards and new teams to form.

This PR aims to encourage Tournament Operators to incorporate Open Qualifiers to their Tournaments through the usage of slight modifiers, helping ensure paths of progression still exist.

Additionally, due to the strength of LANs in awarding points, a slightly harsher penalty is applied to LAN events in the effort of balancing. Potentially also a change to `3.8.3 Tournament Operator may apply additional filters to the VRS lists (e.g., "North America") insofar as they do not lead to the specific targeting of individual Teams or Rosters. For the avoidance of doubt, filtering by country or gender is permitted.` could be beneficial. Changing the ruling so that it is not possible to apply restricting filters on Open LAN events could potentially be an improvement. This would ensure that a restricted filter LAN couldnt be scheduled right before the Major Invites, where teams outside the filter have no chance to contend.

LANs are already restricted enough with the requirement to travel there, an additional filter applied on top of that could potentially lead to abuse of the system, particularly with the lack of buffer in MRQ's.