### PR TITLE
Changes to events during player break

### DIFF
--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -85,6 +85,7 @@ class Event {
         this.lan = eventJson.lan;
         this.lastMatchTime = -1;
         this.finished = eventJson.finished;
+        this.playerBreak = false;
 
         eventJson.prizeDistribution.forEach( teamJson => {
             this.prizeDistributionByTeamId[teamJson.teamId] = new EventTeam( teamJson );
@@ -229,6 +230,20 @@ class DataLoader
             if( event !== undefined )
                 event.accumulateMatch( match );
         } );
+
+        // Identify events that run through the player break
+
+        matches.forEach(match => {
+            if (
+                match.matchStartTime >= 1782082800 &&
+                match.matchStartTime <= 1784502000
+            ) {
+                let event = events[match.eventId];
+                if (event) {
+                    event.playerBreak = true;
+                }
+            }
+        });
 
         // Remove showmatches
         matches = filterShowmatches( matches, events );  

--- a/model/team.js
+++ b/model/team.js
@@ -126,6 +126,7 @@ class Team {
         function powerFunction( x ) { return Math.pow( x, 1 ) };
         function getPrizePool( x ) { return Math.max(1, x.team.eventMap.get( x.match.eventId ).event.prizePool ) };
         function getLAN( x ) { return x.team.eventMap.get( x.match.eventId ).event.lan ? 1 : 0 };
+        function getPlayerBreak ( x ) { return x.team.eventMap.get( x.match.eventId ).event.playerBreak ? 0.5 : 1 };
 
         let bucketSize = 10; // used for all factors that track your top N results
 
@@ -216,7 +217,12 @@ class Team {
                 let id = teamMatch.match.umid;
                 let timestampModifier = context.getTimestampModifier( teamMatch.match.matchStartTime );
                 let prizepool = getPrizePool( teamMatch );
-                let stakesModifier = curveFunction( Math.min( prizepool / 1000000, 1 ) ); //prizepool of the event is curved the same as a bounty, and is limited to $1,000,000.
+
+                let prizePoolStakesModifier = curveFunction( Math.min( prizepool / 1000000, 1 ) ); //prizepool of the event is curved the same as a bounty, and is limited to $1,000,000.
+                let playerBreakStakesModifier = getPlayerBreak ( teamMatch ); // stakes modifier of an event is halved if the event was opearting through the player break.
+
+                let stakesModifier = prizePoolStakesModifier * playerBreakStakesModifier;
+
                 let matchContext = timestampModifier * stakesModifier;
 
                 let scaledBounty = teamMatch.opponent.bountyOffered * matchContext;


### PR DESCRIPTION
Currently the calendar is becoming very congested with a variety of events that teams need to continue to compete in, in the effort to either gain VRS points or try and maintain their position.

The player break has been an important aspect of the ecosystem to help ensure players do not become burnt out. However, as there is no requirement to respect this part of the calendar, events can occur during this period and teams will likely have to compete due to the VRS pressure.

To help ensure player welfare, for the 2026 calendar impose a 50% penalty on the events stakesModifier to discourage events during this period and make attending these events less crucial for teams, giving them some downtime.

Ideally in lower tier scenes this penalty would not be applied as their calendars are often independent to Tier 1 CS. However currently the eventJson does not account for event tiers, so this is not possible.
