### PR TITLE
modifying opponentNetwork

### DIFF
--- a/model/ranking.js
+++ b/model/ranking.js
@@ -14,7 +14,7 @@ const SEED_MODIFIER_FACTORS = {
     bountyCollected: 1,
     bountyOffered: 1,
     opponentNetwork: 1,
-    ownNetwork: 0,
+    ownNetworkImpact: 0,
     lanFactor: 1
 };
 const MIN_SEEDED_RANK = 400;

--- a/model/team.js
+++ b/model/team.js
@@ -76,6 +76,7 @@ class Team {
         this.regionalRank = [-1,-1,-1];
         this.isPendingUpdate = isPendingUpdate;
         this.satisfiesRankingCriteria = false;
+        this.recentWins = 0;
     }
 
     // A past team is considered as the same entity as a more recent one,
@@ -145,6 +146,17 @@ class Team {
             let opponentMap = new Map();
             let lanWins = [];
 
+            // Identify the teams recent form
+            // This is accomplished by populating a recent wins bucket, with their most recent 10 matches.
+            // A team with less than 10 ranked matches will be left with an unfilled bucket.
+
+            let recentMatches = team.teamMatches
+                .slice()
+                .sort((a, b) => b.match.matchStartTime - a.match.matchStartTime)
+                .slice(0, bucketSize); 
+
+            team.recentWins = recentMatches.filter(tm => tm.isWinner).length;
+
             // Calculate the most recent match against each opponent, and also the most recent LAN wins.
             team.wonMatches.forEach( wonMatch => {
                 // Network
@@ -166,6 +178,7 @@ class Team {
             });
 
             // A team's own 'network' is the sum of distinct opponents they defeated, scaled by how long it's been since they defeated them.
+            // ownNetwork is moved from being a team component to a weight for use in a compound component
             opponentMap.forEach( ( lastWinTime, opp ) => {
                 team.distinctTeamsDefeated += context.getTimestampModifier( lastWinTime );
             } );
@@ -201,6 +214,15 @@ class Team {
             team.bountyOffered = Math.min( team.scaledWinnings / referenceWinnings, 1 );
             team.ownNetwork = Math.min( team.distinctTeamsDefeated / referenceOpponentCount, 1 );
             team.lanParticipation = Math.min( team.scaledLanWins / referenceLanWins, 1 );
+            team.winRate = team.recentWins / bucketSize;
+            team.ownNetworkWeight = curveFunction(team.ownNetwork); // ownNetwork is now a weight for networkImpact when previously it was an individual component.
+            team.scaledOwnNetworkImpact = team.winRate * team.ownNetworkWeight; // impact is a teams recent form weighted by ownNetwork.
+        } );
+
+        // Calculate the relative network impact for all teams and then use this to scale the networkImpact accordingly.
+        let referenceOpponentNetworkImpact = nthHighest( teams.map( t => t.scaledOwnNetworkImpact ), context.getOutlierCount() );
+        teams.forEach( team => {
+            team.ownNetworkImpact = Math.min( team.scaledOwnNetworkImpact / referenceOpponentNetworkImpact, 1 );
         } );
 
         // Phase 3 looks at each team's opponents and rates each team highly if it can regularly win against other prestigous teams.
@@ -220,10 +242,10 @@ class Team {
                 let matchContext = timestampModifier * stakesModifier;
 
                 let scaledBounty = teamMatch.opponent.bountyOffered * matchContext;
-                let scaledNetwork = teamMatch.opponent.ownNetwork * matchContext;
+                let scaledNetwork = teamMatch.opponent.ownNetworkImpact * matchContext;
 
                 bounties.push( { id: id, context: stakesModifier, base: teamMatch.opponent.bountyOffered, val: scaledBounty } );
-                network.push(  { id: id, context: stakesModifier, base: teamMatch.opponent.ownNetwork   , val: scaledNetwork } );
+                network.push(  { id: id, context: stakesModifier, base: teamMatch.opponent.ownNetworkImpact   , val: scaledNetwork } );
             } );
     
             bounties.sort( (a,b) => b.val - a.val );
@@ -241,7 +263,7 @@ class Team {
             team.modifiers.bountyCollected  = curveFunction( team.opponentBounties );
             team.modifiers.bountyOffered    = curveFunction( team.bountyOffered );
             team.modifiers.opponentNetwork  = powerFunction( team.opponentNetwork );
-            team.modifiers.ownNetwork       = powerFunction( team.ownNetwork );
+            team.modifiers.ownNetworkImpact       = powerFunction( team.ownNetworkImpact );
             team.modifiers.lanFactor        = powerFunction( team.lanParticipation );
         } );        
     }


### PR DESCRIPTION
This PR proposes a change to the inputs of opponentNetwork, changing it from ownNetwork input to a compound component based on network impact . This is a result of conclusions from previous analysis undertaken.

This change provides limited improvement in the model prediction, however I believe it provides an improvement in understanding and clarity in the model as well as consistent approach in line with other aspects of the model.

Currently, the three other components to opponentNetwork are:

- Bounty Offered - Attained by positive accomplishments in tournaments, earning prizepool.
- Bounty Collected - Attained by positive accomplishments in tournaments, beating other accomplished teams.
- LAN Wins - Reflective of a positive result on LAN

As well as weights which are used to reflect the accuracy of the component & result:

- stakesModifier - Weighting of an event with the relative prizepool of the event. Higher prizepool events will have better teams attending, reflecting the quality of results from that tournament.
- timestampModifier - The recency of the result. More recent results will provide a more accurate picture of how they relate to the current rankings.

The components listed are reflecting solely positive outcomes from teams, whilst weights are reflecting how accurate these results will be in regard to the current ranking period. Teams that have played more matches and by extension beaten more distinct opponents (ownNetwork) will provide a more accurate indication of their position, but this is somewhat more in line with component weights compared to components themself.

ownNetwork (and by extension opponentNetwork) currently is a component that does relate to positive outcomes in isolation, but in the current VRS ecosystem its more related to a neutral outcome and isnt explicitly positive based. 

```js
team.ownNetwork = Math.min( team.distinctTeamsDefeated / referenceOpponentCount, 1 );
```

ownNetwork relates to the number of distinct teams defeated. However, currently it is possible for a team to have a neutral outcome, in which they achieve equal wins and losses over the snapshot period. Whilst the team is not improving its win rate,  they will have an ever increasing ownNetwork. While BCOL and BOFF components reward high stakes value matches, ownNetwork does not. This leads to middle ranked teams being able to grind out low stakes matches increasing their ownNetwork offering whilst not a reflection of top performance and potentially not even their own performance. 

This of no benefit to the team itself, however it benefits the teams around them. Due to the size of the network in T2 Europe this provides significant advantage to EU teams with teams having more opportunity to play more varied opponents.  This then helps provide a soft foundation boost to teams competing within Europe.

The ownNetwork a team offers is not indicated on team reports and is hard to guage for teams assessing what events they should attend. Its possible to calculate through the details/{team}.md but its less intuitive then a team being inform.



Ideally, all components should relate to the final rank value, indicating the component works in tandem with the other components.

When graphing BOFF and BCOL you see strong relations to the final rank:

<img width="3600" height="2400" alt="bounty_collected_vs_final_rank_value_by_region_07_22_fr" src="https://github.com/user-attachments/assets/f6e1702e-ed64-4090-bc8b-b3f50a675d1a" />

<img width="3600" height="2400" alt="bounty_offered_vs_final_rank_value_by_region_07_22_fr" src="https://github.com/user-attachments/assets/a4966a3c-f05f-4afd-9b0d-d4b7bb91c4bd" />

However, when graphing ownNetwork you see the points on offer to other teams does not necessarily reflect the calibre of that team. While Tier 1 teams play higher quality matches, they play them more sparsely and against more consistent opponents. Therefore their ownNetwork will be lower than teams with more varied matches in the T2 circuit.

<img width="3600" height="2400" alt="own_network_vs_final_rank_value_by_region_07_22_fr" src="https://github.com/user-attachments/assets/1acf7065-a798-442c-98e6-9b73458e9337" />

This then has the following affect on opponentNetwork

<img width="3600" height="2400" alt="opponent_network_vs_final_rank_value_by_region_07_22_fr" src="https://github.com/user-attachments/assets/dc1d4378-9d63-4bb2-a25b-7aa33076e0c8" />

As theorised from the methodology of ownNetwork and opponentNetwork, the network component is rather dominated by EU teams. Its particularly noticeable by the EU teams which have a high opponent network but a lower overall rank, indicating they perform poorly in the other components. Top teams are offering lower network points than Tier 2 EU teams, even while these top teams are regularly competing in the top circuit against the best network / cluster of teams.

## Changes

This PR proposed change is modifying opponentNetwork to be fed by ownNetworkImpact.

This is a compound component of the recent form of a team, weighted by their ownNetwork. The metric represents the impact of a team within their individual network. Similar to the other weights within the model, ownNetwork is treated as the accuracy weight for this component. This approach helps ensure that the network component isn't inherently tied to the size of the scene or the ability for a team to have the opportunity to compete in a larger / more varied scene.

This leads to the following change of ownNetwork (now ownNetworkImpact):

<img width="3600" height="2400" alt="own_network_impact_vs_final_rank_value_by_region_modify_fr" src="https://github.com/user-attachments/assets/274bfcea-f7a1-480e-9462-308be479e1be" />

With these inputs affecting opponentNetwork as shown:

<img width="3600" height="2400" alt="opponent_network_vs_final_rank_value_by_region_modify_fr" src="https://github.com/user-attachments/assets/379ec84e-23b2-4f54-94a5-7d7c84488226" />

The effect is incredibly minor. However, the European dominance is reigned in as well as Tier 1 teams that are performing well in the Tier 1 network are offering more points, reflecting their performance within their own individual network. The change potentially provides a more understandable outcome, in which you're gaining points off of a team in form. opponentNetwork also has an improved relation to final rank value as well as an improved Spearman's Rho, indicating it may work in tandem with the other components.

When graphing the two methodologies for the model as a whole:


Current:

<img width="853" height="507" alt="image" src="https://github.com/user-attachments/assets/ef9f3d0e-488c-4a4d-a3a1-a6e84e6fb988" />

Proposed:

<img width="844" height="514" alt="image" src="https://github.com/user-attachments/assets/ab19c353-a861-4cb1-951c-66280414f369" />


## Outcome

This PR sees relatively little improvement on the overarching model, however its main benefit is improving the logical process in earning points, general understanding of the model and consistency between components. Given the separation of individual networks / clusters, a metric which identifies the impact of a team within its own network is potentially more reflective than a global network component which is more closely tied to size of the scene.

Implementation of this would have limited impact upon the top 20, with only one position swap. With two teams swapping positions which were previously separated by an incredibly narrow gap. Even across the whole ranking model it has limited impact.

Potentially an improvement, albeit minor. opponentNetwork currently sits in a similar relation to lanWins where it doesnt have a perfect reflection to teams' performance. I think the general assumption is the current lanWins approach is to incentivize teams playing on LAN. If theres similar reasoning for opponentNetwork this may potentially sway the favour back towards the current implementation.

