### PR TITLE
Adjusting LAN wins modifier

### DIFF
--- a/model/data_loader.js
+++ b/model/data_loader.js
@@ -85,6 +85,7 @@ class Event {
         this.lan = eventJson.lan;
         this.lastMatchTime = -1;
         this.finished = eventJson.finished;
+        this.openSignups = eventJson.openSignups;
 
         // connect qualified events
         let qualifiedEvents = [];


### PR DESCRIPTION
While the full effects have not been realised yet, there is a current rush for LAN wins at open signup events.

This rush has created an economic arms race, teams are now effectively required to attend & sustain a much higher LAN win bucket for a chance at progression or advancement due to this sudden increase in saturation.

## Proposal 

This PR proposes limiting the maximum number of LAN wins achievable from open signup LAN events. Open LANs still have significant value, with the ability to gain LAN wins at an un-scaled rate, but it reduces the need for teams to attend every LAN possible.  The total bucket size remains unchange, with non open signup LAN wins being unaffected.

This would hopefully lower the costs of competing, stalling the economic arms race, whilst enabling more flexibility for teams and being able to choose and select what LANs to attend. Teams would have the incentive to spread out their efforts, selecting tournaments based on cost, location, opponents and more without flooding the space. Local LAN TO's should hopefully see a more sustainable cycle, with a more even distribution of turnout across the year.

HLTV already collects the data on whether an event was open signup in the TO coverage application submission and would require addition to the matchdata collected.

A reduction in the saturation of the LAN win modifier, would also help ensure that the other components still have reasonable impact, particularly in the lower tiers. This also would have no effect on Tier 1, with the events being invited based as well as still incentivizing Tier 2 tournament operators to host LAN stages and finals. 

## Model Effects

The current model evaluation is:
<img width="800" height="600" alt="calibration_intra_binned_new" src="https://github.com/user-attachments/assets/aeedfe71-3624-434a-8adf-00b909d2d5a5" />

With this PR having the below effect on the current model:
<img width="800" height="600" alt="calibration_overall_binned_lanwin" src="https://github.com/user-attachments/assets/841ce1e3-2078-4b23-8952-d5bfd944f222" />

With the outcome being an improvement in Spearman's Rho and a steeper slope.

## Final views

This PR potentially sees ranking benefits, increasing the balance between modifier values, reducing the saturation of LAN wins and an improvement in match result prediction.

It potentially would also see scene level benefits, reducing the input cost for teams and reducing the reliance on having to attend a lot of events to have a near full LAN bucket to try and challenge for the major slots.

A potential issue is the effect on Local LAN TO's, hopefully a max bucket of 5 would act as a suitable balance for both TO's and team economics.


